### PR TITLE
feat: Download QR as PNG (+E2E)

### DIFF
--- a/e2e/extension.e2e.js
+++ b/e2e/extension.e2e.js
@@ -52,6 +52,19 @@ const fs = require('fs');
     console.log('[debug] #qr innerHTML (first 300):', html.slice(0, 300));
     throw new Error('QR element not found');
   }
+
+  // Test: download PNG
+  const downloadsDir = require('path').join(process.cwd(), 'e2e', 'artifacts');
+  require('fs').mkdirSync(downloadsDir, { recursive: true });
+  const [download] = await Promise.all([
+    page.waitForEvent('download'),
+    page.locator('#download').click(),
+  ]);
+  const target = require('path').join(downloadsDir, await download.suggestedFilename());
+  await download.saveAs(target);
+  const size = require('fs').statSync(target).size;
+  if (size < 1000) throw new Error('Downloaded PNG seems too small');
+  console.log('[ok] Downloaded PNG:', target, size, 'bytes');
   console.log('[ok] Extension popup rendered with ID', extId);
   await context.close();
 })();

--- a/popup.html
+++ b/popup.html
@@ -21,6 +21,7 @@
     <div class="row">
       <input id="url" type="text" readonly />
       <button id="copy">Copy</button>
+      <button id="download" title="Download QR as PNG">Download</button>
     </div>
     <footer>
       Tip: Show this on your phone by scanning the code.
@@ -30,4 +31,3 @@
     <script src="popup.js" type="module"></script>
   </body>
   </html>
-

--- a/popup.js
+++ b/popup.js
@@ -6,6 +6,7 @@ const $ = (s) => document.querySelector(s);
 const qrBox = $('#qr');
 const urlInput = $('#url');
 const copyBtn = $('#copy');
+const downloadBtn = $('#download');
 
 async function getActiveTabUrl() {
   // Test hook: if ?u=<url> is provided, prefer it (works in chrome-extension://, http(s) and file://)
@@ -57,6 +58,30 @@ copyBtn.addEventListener('click', async () => {
   } catch (e) {
     copyBtn.textContent = 'Copy failed';
     setTimeout(() => (copyBtn.textContent = 'Copy'), 1200);
+  }
+});
+
+downloadBtn.addEventListener('click', async () => {
+  try {
+    // Prefer the generated <img>, fall back to canvas
+    const img = qrBox.querySelector('img');
+    let dataUrl = '';
+    if (img && img.src.startsWith('data:image')) {
+      dataUrl = img.src;
+    } else {
+      const canvas = qrBox.querySelector('canvas');
+      if (canvas && canvas.toDataURL) dataUrl = canvas.toDataURL('image/png');
+    }
+    if (!dataUrl) throw new Error('QR image not ready');
+    const a = document.createElement('a');
+    a.href = dataUrl;
+    const ts = new Date().toISOString().replace(/[:.]/g, '-');
+    a.download = `qr-${ts}.png`;
+    document.body.appendChild(a);
+    a.click();
+    a.remove();
+  } catch (e) {
+    console.error('Download failed', e);
   }
 });
 


### PR DESCRIPTION
Adds a Download button to save the generated QR as PNG and extends Playwright E2E to verify the download path and file size.\n\n- UI: adds Download button\n- Logic: collects data URL from img/canvas and triggers download\n- E2E: verifies QR render + download via Playwright\n